### PR TITLE
Fix print_timed in Julia v1.8

### DIFF
--- a/src/Timing/Timing.jl
+++ b/src/Timing/Timing.jl
@@ -17,8 +17,14 @@ Print the result of a `@timed` call.
 - `stats` -- the result of a `@timed` call
 """
 function print_timed(stats::NamedTuple)
-    Base.time_print(stats.time * 1e9, stats.bytes, stats.gctime * 1e9,
-                    Base.gc_alloc_count(stats.gcstats), 0, true)
+    @static if VERSION >= v"1.8"
+        Base.time_print(stats.time * 1e9, stats.bytes, stats.gctime * 1e9,
+                        Base.gc_alloc_count(stats.gcstats), 0, 0, true)
+    else
+        # did not have argument `recompile_time` yet
+        Base.time_print(stats.time * 1e9, stats.bytes, stats.gctime * 1e9,
+                        Base.gc_alloc_count(stats.gcstats), 0, true)
+    end
 end
 
 end  # module


### PR DESCRIPTION
Output in v1.8 in `master`:

```julia
0.000000 seconds: Inf% of which was recompilation
```

The reason is that another argument was added to `Base.time_print`.