### PR TITLE
Use package extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,4 +17,15 @@ LinearAlgebra = "<0.0.1, 1.2"
 Random = "<0.0.1, 1.2"
 Requires = "0.5, 1"
 SparseArrays = "<0.0.1, 1.2"
+StaticArrays = "1"
 julia = "1.2"
+
+[extensions]
+StaticArraysExt = "StaticArrays"
+
+[extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[weakdeps]
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/ext/StaticArraysExt.jl
+++ b/ext/StaticArraysExt.jl
@@ -1,0 +1,21 @@
+module StaticArraysExt
+
+using ReachabilityBase.Arrays
+
+@static if isdefined(Base, :get_extension)
+    import StaticArrays
+else
+    import ..StaticArrays
+end
+
+# represent the projection matrix with a static array
+function Arrays.projection_matrix(block::AbstractVector{Int}, n::Int,
+                                  ::Type{<:StaticArrays.SVector{L,N}}) where {L,N}
+    mat = projection_matrix(block, n, N)
+    m = size(mat, 1)
+    return StaticArrays.SMatrix{m,n}(mat)
+end
+
+Arrays.similar_type(x::StaticArrays.StaticArray) = StaticArrays.similar_type(x)
+
+end  # module

--- a/src/Arrays/Arrays.jl
+++ b/src/Arrays/Arrays.jl
@@ -8,7 +8,6 @@ module Arrays
 using Base: /
 using LinearAlgebra: Diagonal, \, cond, det, diag, eigvals, norm, qr, transpose
 using Random: AbstractRNG, GLOBAL_RNG
-using Requires: @require
 using SparseArrays: AbstractSparseArray, AbstractSparseMatrix,
                     AbstractSparseVector, SparseMatrixCSC, SparseVector,
                     dropzeros!, sparse, sparsevec, spzeros

--- a/src/Arrays/init.jl
+++ b/src/Arrays/init.jl
@@ -1,3 +1,9 @@
-function __init__()
-    @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("init_StaticArrays.jl")
+@static if !isdefined(Base, :get_extension)
+    using Requires
+end
+
+@static if !isdefined(Base, :get_extension)
+    function __init__()
+        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../../ext/StaticArraysExt.jl")
+    end
 end

--- a/src/Arrays/init_StaticArrays.jl
+++ b/src/Arrays/init_StaticArrays.jl
@@ -1,4 +1,0 @@
-using .StaticArrays: SMatrix, SVector
-
-eval(load_projection_matrix_static())
-eval(load_copy_finalize_static())

--- a/src/Arrays/matrix_operations.jl
+++ b/src/Arrays/matrix_operations.jl
@@ -279,18 +279,6 @@ function projection_matrix(block::AbstractVector{Int}, n::Int,
     return projection_matrix(block, n, N)
 end
 
-function load_projection_matrix_static()
-    return quote
-        # represent the projection matrix with a static array
-        function projection_matrix(block::AbstractVector{Int}, n::Int,
-                                   VN::Type{<:SVector{L,N}}) where {L,N}
-            mat = projection_matrix(block, n, N)
-            m = size(mat, 1)
-            return SMatrix{m,n}(mat)
-        end
-    end # quote
-end # end load_projection_matrix_static
-
 """
     remove_zero_columns(A::AbstractMatrix)
 

--- a/src/Arrays/matrix_vector_operations.jl
+++ b/src/Arrays/matrix_vector_operations.jl
@@ -141,9 +141,3 @@ end
 
 # no-op
 similar_type(x::AbstractVector) = typeof(x)
-
-function load_copy_finalize_static()
-    return quote
-        similar_type(x::StaticArrays.StaticArray) = StaticArrays.similar_type(x)
-    end # quote
-end # end load_copy_finalize_static

--- a/test/quality_assurance.jl
+++ b/test/quality_assurance.jl
@@ -22,5 +22,12 @@ import Pkg
 end
 
 @testset "Aqua tests" begin
-    Aqua.test_all(ReachabilityBase)
+    # Requires is only used in old versions
+    @static if VERSION >= v"1.9"
+        stale_deps = (ignore=[:Requires],)
+    else
+        stale_deps = true
+    end
+
+    Aqua.test_all(ReachabilityBase; stale_deps=stale_deps)
 end


### PR DESCRIPTION
The only noticable change is that `similar_type` now creates a conflict when loading both this package and `StaticArrays`. At least I do not see how to work around this with package extensions. But maybe that is fair. In fact, the problem existed before; there was just no direct warning when `using` both packages, but the warning appeared when trying to access the symbol:

```julia
julia> using ReachabilityBase.Arrays

julia> using StaticArrays  # no warning here

julia> similar_type
ERROR: UndefVarError: `similar_type` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name, resulting in ambiguity. Try explicitly importing it from a particular module, or qualifying the name with the module it should come from.
Hint: a global variable of this name also exists in StaticArrays.
```