### PR TITLE
Use default value 2 for `norm` of `SingleEntryVector`

### DIFF
--- a/src/Arrays/SingleEntryVector.jl
+++ b/src/Arrays/SingleEntryVector.jl
@@ -73,7 +73,7 @@ function inner(e1::SingleEntryVector{N}, A::AbstractMatrix{N},
 end
 
 # norm
-function LinearAlgebra.norm(e::SingleEntryVector, ::Real=Inf)
+function LinearAlgebra.norm(e::SingleEntryVector, ::Real=2)
     return abs(e.v)
 end
 


### PR DESCRIPTION
This change has no effect because the argument is ignored. The motivation is only to use the default value from `LinearAlgebra`.