### PR TITLE
Revise `array_operations` code and tests and generalize code

### DIFF
--- a/docs/src/lib/Comparison.md
+++ b/docs/src/lib/Comparison.md
@@ -15,6 +15,12 @@ CurrentModule = ReachabilityBase.Comparison
 Comparison
 ```
 
+## Exact comparison
+
+```@docs
+isidentical
+```
+
 ## Tolerance
 
 ```@docs

--- a/src/Arrays/Arrays.jl
+++ b/src/Arrays/Arrays.jl
@@ -1,7 +1,7 @@
 """
     Arrays
 
-This module provides machinery for vectors and matrices.
+This module provides machinery for vectors, matrices, and general arrays.
 """
 module Arrays
 
@@ -12,16 +12,14 @@ using Requires: @require
 using SparseArrays: AbstractSparseArray, AbstractSparseMatrix,
                     AbstractSparseVector, SparseMatrixCSC, SparseVector,
                     dropzeros!, sparse, sparsevec, spzeros
+using ReachabilityBase.Comparison: _geq, _in, isapproxzero, _isapprox
+using ReachabilityBase.Commutative: @commutative
+
+import Base: +, -, *, getindex, rationalize, size
+import LinearAlgebra: dot, norm, rank
 
 using ReachabilityBase.Assertions: @assert, activate_assertions
 activate_assertions(Arrays)  # activate assertions by default
-
-using ReachabilityBase.Comparison: _geq, isapproxzero, _isapprox, _in
-
-using ReachabilityBase.Commutative: @commutative
-
-import Base: rationalize
-import LinearAlgebra: dot, norm, rank
 
 export abs_sum,
        append_zeros,
@@ -74,12 +72,13 @@ export abs_sum,
     export allequal
 end
 
-include("SingleEntryVector.jl")
 include("array_operations.jl")
 include("matrix_operations.jl")
 include("vector_operations.jl")
 include("matrix_vector_operations.jl")
 include("logarithmic_norm.jl")
+include("SingleEntryVector.jl")
+
 include("init.jl")
 
 end  # module

--- a/src/Arrays/SingleEntryVector.jl
+++ b/src/Arrays/SingleEntryVector.jl
@@ -7,131 +7,149 @@ A sparse unit vector with arbitrary one-element.
 
 - `i` -- index of non-zero entry
 - `n` -- vector length
-- `v` -- non-zero entry
+- `v` -- (potentially) non-zero value (defaults to `one(N)` if not passed)
 """
 struct SingleEntryVector{N} <: AbstractVector{N}
     i::Int
     n::Int
     v::N
-end
 
-# convenience constructor with one-element of corresponding type
-SingleEntryVector{N}(i::Int, n::Int) where {N} = SingleEntryVector{N}(i, n, one(N))
+    function SingleEntryVector{N}(i::Int, n::Int, v::N=one(N)) where {N}
+        @assert 1 <= i <= n || throw(ArgumentError("invalid index $i for vector of length $n"))
 
-function Base.getindex(e::SingleEntryVector{N}, i::Int) where {N}
-    @boundscheck 1 <= i <= e.n || throw(BoundsError(e, i))
-    return i == e.i ? e.v : zero(N)
-end
-
-Base.size(e::SingleEntryVector) = (e.n,)
-
-# define matrix-vector multiplication with SingleEntryVector
-# due to type piracy in other packages, we need to enumerate the matrix types
-# explicitly here
-for MT in [Matrix, AbstractSparseMatrix]
-    function Base.:(*)(A::MT, e::SingleEntryVector)
-        return A[:, e.i] * e.v
+        return new{N}(i, n, v)
     end
 end
 
-# multiplication with diagonal matrix
-function Base.:(*)(D::Diagonal{N,V},
-                   e::SingleEntryVector{N}) where {N,V<:AbstractVector{N}}
-    return SingleEntryVector(e.i, e.n, D.diag[e.i] * e.v)
+# constructor without type parameter
+function SingleEntryVector(i::Int, n::Int, v::N) where {N}
+    return SingleEntryVector{N}(i, n, v)
+end
+
+function getindex(x::SingleEntryVector{N}, i::Int) where {N}
+    @boundscheck 1 <= i <= x.n || throw(BoundsError(x, i))
+    return i == x.i ? x.v : zero(N)
+end
+
+function size(x::SingleEntryVector)
+    return (x.n,)
 end
 
 # negation
-function Base.:(-)(e::SingleEntryVector{N}) where {N}
-    return SingleEntryVector(e.i, e.n, -e.v)
+function -(x::SingleEntryVector)
+    return SingleEntryVector(x.i, x.n, -x.v)
 end
 
 # arithmetic
 for (opS, opF) in ((:(+), +), (:(-), -))
     @eval begin
-        function Base.$opS(e1::SingleEntryVector{N}, e2::SingleEntryVector{N}) where {N}
-            if e1.n != e2.n
-                throw(DimensionMismatch("dimensions must match, but they are $(length(e1)) and $(length(e2)) respectively"))
+        function $opS(x1::SingleEntryVector, x2::SingleEntryVector)
+            @assert x1.n == x2.n ||
+                    throw(DimensionMismatch("dimensions must match, but they are " *
+                                            "$(length(x1)) and $(length(x2)) respectively"))
+
+            if x1.i == x2.i
+                return SingleEntryVector(x1.i, x1.n, $opF(x1.v, x2.v))
             end
 
-            if e1.i == e2.i
-                return SingleEntryVector(e1.i, e1.n, $opF(e1.v, e2.v))
-            else
-                res = spzeros(N, e1.n)
-                @inbounds begin
-                    res[e1.i] = e1.v
-                    res[e2.i] = $opF(e2.v)
-                end
-                return res
+            N = promote_type(eltype(x1), eltype(x2))
+            y = spzeros(N, x1.n)
+            @inbounds begin
+                y[x1.i] = x1.v
+                y[x2.i] = $opF(x2.v)
             end
+            return y
         end
     end
 end
 
-function inner(e1::SingleEntryVector{N}, A::AbstractMatrix{N},
-               e2::SingleEntryVector{N}) where {N}
-    return A[e1.i, e2.i] * e1.v * e2.v
+# x1 * M * x2
+function inner(x1::SingleEntryVector, M::AbstractMatrix, x2::SingleEntryVector)
+    @assert size(M) == (length(x1), length(x2)) ||
+            throw(DimensionMismatch("dimensions must match, but they are " *
+                                    "$(length(x1)), $(size(M)), and $(length(x2)) respectively"))
+
+    return x1.v * M[x1.i, x2.i] * x2.v
 end
 
-# norm
-function norm(e::SingleEntryVector, ::Real=2)
-    return abs(e.v)
+function append_zeros(x::SingleEntryVector, n::Int)
+    return SingleEntryVector(x.i, x.n + n, x.v)
 end
 
-function append_zeros(e::SingleEntryVector, n::Int)
-    return SingleEntryVector(e.i, e.n + n, e.v)
+function prepend_zeros(x::SingleEntryVector, n::Int)
+    return SingleEntryVector(x.i + n, x.n + n, x.v)
 end
 
-function prepend_zeros(e::SingleEntryVector, n::Int)
-    return SingleEntryVector(e.i + n, e.n + n, e.v)
+function norm(x::SingleEntryVector, p::Real=2)
+    @assert p >= one(p) || throw(ArgumentError("invalid p-norm p=$p"))
+
+    return abs(x.v)
 end
 
-# distance = norm of the difference ||x - y||_p
-function distance(e1::SingleEntryVector{N}, e2::SingleEntryVector{N}; p::Real=N(2)) where {N}
-    if e1.n != e2.n
-        throw(DimensionMismatch("dimensions must match, but they are " *
-                                "$(length(e1)) and $(length(e2)) respectively"))
-    end
+# distance = norm of the difference ‖x - y‖_p
+function distance(x1::SingleEntryVector, x2::SingleEntryVector; p::Real=2)
+    @assert x1.n == x2.n || throw(DimensionMismatch("dimensions must match, but they are " *
+                                                    "$(length(x1)) and $(length(x2)) respectively"))
+    @assert p >= one(p) || throw(ArgumentError("invalid p-norm p=$p"))
 
-    if e1.i == e2.i
-        return abs(e1.v - e2.v)
+    if x1.i == x2.i
+        # simple case for vector with only one entry
+        return abs(x1.v - x2.v)
     else
-        a = abs(e1.v)
-        b = abs(e2.v)
-        if isinf(p)
-            return max(a, b)
-        else
-            s = a^p + b^p
-            return s^(1 / p)
-        end
+        # vector has only two entries; use LinearAlgebra's implementation
+        return norm((x1.v, x2.v), p)
     end
+end
+
+# ‖xᵀ M‖₁
+function abs_sum(x::SingleEntryVector, M::AbstractMatrix)
+    @assert length(x) == size(M, 1) ||
+            throw(DimensionMismatch("dimensions must match, but they are " *
+                                    "$(length(x)) and $(size(M)) respectively"))
+
+    return sum(abs, @view(M[x.i, :])) * abs(x.v)
 end
 
 # matrix-vector multiplication
-@inline function At_mul_B(A, b::SingleEntryVector)
-    if size(A, 1) != length(b)
-        throw(DimensionMismatch("dimensions must match, but they are " *
-                                "$(size(A)) and $(length(b)) respectively"))
-    end
+for MT in (Matrix, AbstractSparseMatrix)
+    # `Base.:(*)` needed to avoid error
+    function Base.:(*)(M::MT, x::SingleEntryVector)
+        @assert size(M, 2) == length(x) ||
+                throw(DimensionMismatch("dimensions must match, but they are " *
+                                        "$(size(M)) and $(length(x)) respectively"))
 
-    return @view(A[b.i, :]) .* b.v
+        return @view(M[:, x.i]) * x.v
+    end
 end
 
-# vector-matrix multiplication
-@inline function At_mul_B(a::SingleEntryVector, B)
-    if length(a) != size(B, 1)
-        throw(DimensionMismatch("dimensions must match, but they are " *
-                                "$(length(a)) and $(size(B)) respectively"))
-    end
+# multiplication with Diagonal
+function *(D::Diagonal, x::SingleEntryVector)
+    @assert size(D, 2) == length(x) ||
+            throw(DimensionMismatch("dimensions must match, but they are " *
+                                    "$(size(D)) and $(length(x)) respectively"))
 
-    return a.v * @view(B[a.i, :])
+    return SingleEntryVector(x.i, x.n, D.diag[x.i] * x.v)
 end
 
-# vector-vector multiplication
-@inline function At_mul_B(a::SingleEntryVector, b::SingleEntryVector)
-    if length(a) != length(b)
-        throw(DimensionMismatch("dimensions must match, but they are " *
-                                "$(length(a)) and $(length(b)) respectively"))
-    end
+# transposed matrix-vector multiplication
+function At_mul_B(A, b::SingleEntryVector)
+    @assert size(A, 1) == length(b) ||
+            throw(DimensionMismatch("dimensions must match, but they are " *
+                                    "$(size(A)) and $(length(b)) respectively"))
+
+    return @view(A[b.i, :]) * b.v
+end
+
+# transposed vector-matrix multiplication
+function At_mul_B(a::SingleEntryVector, B)
+    return At_mul_B(B, a)
+end
+
+# transposed vector-vector multiplication
+function At_mul_B(a::SingleEntryVector, b::SingleEntryVector)
+    @assert length(a) == length(b) ||
+            throw(DimensionMismatch("dimensions must match, but they are " *
+                                    "$(length(a)) and $(length(b)) respectively"))
 
     if a.i == b.i
         return [a.v * b.v]

--- a/src/Arrays/array_operations.jl
+++ b/src/Arrays/array_operations.jl
@@ -1,123 +1,121 @@
 """
-    same_sign(A::AbstractArray{N}; [optimistic]::Bool=false) where {N}
+    same_sign(A::AbstractArray)
 
 Check whether all elements of the given array have the same sign.
 
 ### Input
 
-- `A`          -- array
-- `optimistic` -- (optional; default: `false`) flag for expressing that the
-                  expected result is `true`
+- `A` -- array
 
 ### Output
 
-`true` if and only if all elements in `M` have the same sign.
+`true` iff all elements in `A` have the same sign.
 
 ### Algorithm
 
-If `optimistic` is `false`, we check the sign of the first element and compare
-to the sign of all elements.
-
-If `optimistic` is `true`, we compare the absolute element sum with the sum of
-the absolute of the elements; this is faster if the result is `true` because
-there is no branching.
-
-```math
-    |\\sum_i A_i| = \\sum_i |A_i|
-```
+We check the sign of the first element and compare to the sign of all elements.
 """
-function same_sign(A::AbstractArray{N}; optimistic::Bool=false) where {N}
-    if optimistic
-        return sum(abs, A) == abs(sum(A))
+function same_sign(A::AbstractArray)
+    if isempty(A)
+        return true
+    end
+    N = eltype(A)
+    @inbounds if first(A) >= zero(N)
+        return all(e -> e >= zero(N), A)
     else
-        if isempty(A)
-            return true
-        end
-        @inbounds if first(A) >= zero(N)
-            return all(e -> e >= zero(N), A)
-        else
-            return all(e -> e <= zero(N), A)
-        end
+        return all(e -> e <= zero(N), A)
     end
 end
 
 """
-    rationalize(::Type{T}, x::AbstractArray{N}, tol::Real) where {T<:Integer, N<:AbstractFloat}
+    rationalize(::Type{T}, A::AbstractArray{N}, tol::Real) where {T<:Integer, N<:AbstractFloat}
 
-Approximate an array of floating point numbers as a rational vector with entries
+Approximate an array of floating-point numbers as an array with rational entries
 of the given integer type.
 
 ### Input
 
 - `T`   -- (optional, default: `Int`) integer type to represent the rationals
-- `x`   -- vector of floating point numbers
-- `tol` -- (optional, default: `eps(N)`) tolerance the result at entry `i`
-           will differ from `x[i]` by no more than `tol`
+- `A`   -- array of floating-point numbers
+- `tol` -- (optional, default: `eps(N)`) tolerance; the result at entry `i`
+           will differ from `A[i]` by no more than `tol`
 
 ### Output
 
 An array of type `Rational{T}` where the `i`-th entry is the rationalization
-of the `i`-th component of `x`.
+of the `i`-th component of `A`.
 
 ### Notes
 
 See also `Base.rationalize`.
 """
-function rationalize(::Type{T}, x::AbstractArray{N}, tol::Real) where {T<:Integer,N<:AbstractFloat}
-    return rationalize.(Ref(T), x, Ref(tol))
+function rationalize(::Type{T}, A::AbstractArray{N}, tol::Real) where {T<:Integer,N<:AbstractFloat}
+    B = similar(A, Rational{T})
+    @inbounds for i in eachindex(A)
+        B[i] = rationalize(T, A[i], tol)
+    end
+    return B
 end
 
-# method extensions
-function rationalize(::Type{T}, x::AbstractArray{N};
+# `tol` as kwarg with default value
+function rationalize(::Type{T}, A::AbstractArray{N};
                      tol::Real=eps(N)) where {T<:Integer,N<:AbstractFloat}
-    return rationalize(T, x, tol)
-end
-function rationalize(x::AbstractArray{N}; kwargs...) where {N<:AbstractFloat}
-    return rationalize(Int, x; kwargs...)
+    return rationalize(T, A, tol)
 end
 
-# nested vectors
-function rationalize(::Type{T}, x::AbstractArray{<:AbstractArray{N}},
+# no `T` with default value
+function rationalize(A::AbstractArray{N}; kwargs...) where {N<:AbstractFloat}
+    return rationalize(Int, A; kwargs...)
+end
+
+# nested arrays
+function rationalize(::Type{T}, A::AbstractArray{<:AbstractArray{N}},
                      tol::Real) where {T<:Integer,N<:AbstractFloat}
-    return rationalize.(Ref(T), x, Ref(tol))
+    return rationalize.(Ref(T), A, Ref(tol))
 end
 
 """
-    rectify(x::AbstractArray{N}) where {N<:Real}
+    rectify(A::AbstractArray)
 
 Rectify an array, i.e., take the element-wise maximum with zero.
 
 ### Input
 
-- `x` -- array
+- `A` -- array
 
 ### Output
 
 A copy of the array where each negative entry is replaced by zero.
 """
-function rectify(x::AbstractArray{N}) where {N<:Real}
-    return map(xi -> max(xi, zero(N)), x)
+function rectify(A::AbstractArray)
+    B = similar(A)
+    z = zero(eltype(A))
+    @inbounds for i in eachindex(A)
+        B[i] = max(A[i], z)
+    end
+    return B
 end
 
 """
-    argmaxabs(x::AbstractArray)
+    argmaxabs(A::AbstractArray)
 
-Return the index with the absolute-wise maximum entry.
+Return the first index with the absolute-wise maximum entry.
 
 ### Input
 
-- `x` -- array
+- `A` -- array
 
 ### Output
 
-The index `i` such that `|x[i]| >= |x[j]|` for all `j`.
+The first (wrt. `eachindex`) index `i` such that `|A[i]| >= |A[j]|` for all `j`.
 """
-function argmaxabs(x::AbstractArray)
-    @assert length(x) > 0 "cannot find the absolute argmax in an empty array"
-    res = zero(eltype(x))
+function argmaxabs(A::AbstractArray)
+    @assert !isempty(A) || throw(ArgumentError("cannot find the absolute argmax in an empty array"))
+
+    res = zero(eltype(A))
     idx = 1
-    @inbounds for i in eachindex(x)
-        v = abs(x[i])
+    @inbounds for i in eachindex(A)
+        v = abs(A[i])
         if v > res
             res = v
             idx = i

--- a/src/Arrays/logarithmic_norm.jl
+++ b/src/Arrays/logarithmic_norm.jl
@@ -54,7 +54,7 @@ function logarithmic_norm_inf(A::AbstractMatrix{N}) where {N}
     return out
 end
 
-# max_j  1/2 * λⱼ(A + A^T)
+# max_j  1/2 * λⱼ(A + Aᵀ)
 function logarithmic_norm_2(A::AbstractMatrix)
     B = A + A'
     λ = eigvals(B)

--- a/src/Arrays/matrix_vector_operations.jl
+++ b/src/Arrays/matrix_vector_operations.jl
@@ -1,43 +1,26 @@
-# computes ‖a^T G‖₁
-@inline function abs_sum(a::AbstractVector, G::AbstractMatrix)
-    @assert length(a) == size(G, 1) "invalid dimensions $(length(a)) and $(size(G))"
+# computes ‖xᵀ M‖₁
+@inline function abs_sum(x::AbstractVector, M::AbstractMatrix)
+    @assert length(x) == size(M, 1) "invalid dimensions $(length(x)) and $(size(M))"
 
-    n, p = size(G)
-    N = promote_type(eltype(a), eltype(G))
+    n, p = size(M)
+    N = promote_type(eltype(x), eltype(M))
     res = zero(N)
     @inbounds for j in 1:p
         aux = zero(N)
         @simd for i in 1:n
-            aux += a[i] * G[i, j]
+            aux += x[i] * M[i, j]
         end
         res += abs(aux)
     end
     return res
 end
 
-# computes ‖a^T G‖₁ for `a` being a sparse vector
-@inline function abs_sum(a::AbstractSparseVector, G::AbstractMatrix)
-    return sum(abs, transpose(a) * G)
-end
-
-# computes ‖a^T G‖₁ for `a` having only one nonzero element
-@inline function abs_sum(a::SingleEntryVector, G::AbstractMatrix)
-    @assert length(a) == size(G, 1) "invalid dimensions $(length(a)) and $(size(G))"
-
-    p = size(G, 2)
-    i = a.i
-    N = promote_type(eltype(a), eltype(G))
-    res = zero(N)
-    @inbounds for j in 1:p
-        res += abs(G[i, j])
-    end
-    res *= abs(a.v)
-    return res
+@inline function abs_sum(x::AbstractSparseVector, M::AbstractMatrix)
+    return sum(abs, transpose(x) * M)
 end
 
 """
-    inner(x::AbstractVector{N}, A::AbstractMatrix{N}, y::AbstractVector{N}
-         ) where {N}
+    inner(x::AbstractVector{N}, A::AbstractMatrix{N}, y::AbstractVector{N}) where {N}
 
 Compute the inner product ``xᵀ A y``.
 

--- a/src/Arrays/vector_operations.jl
+++ b/src/Arrays/vector_operations.jl
@@ -143,36 +143,6 @@ function _ismultiple(u::AbstractVector, v::AbstractVector; allow_negative::Bool)
 end
 
 """
-    nonzero_indices(v::AbstractVector{N}) where {N<:Real}
-
-Return the indices in which a vector is non-zero.
-
-### Input
-
-- `v` -- vector
-
-### Output
-
-A vector of ascending indices `i` such that the vector is non-zero in dimension
-`i`.
-"""
-function nonzero_indices(v::AbstractVector{N}) where {N<:Real}
-    n = length(v)
-    res = Vector{Int}()
-    sizehint!(res, n)
-    for i in 1:n
-        if v[i] != zero(N)
-            push!(res, i)
-        end
-    end
-    return res
-end
-
-function nonzero_indices(v::SparseVector{N}) where {N<:Real}
-    return v.nzind
-end
-
-"""
     is_cyclic_permutation(candidate::AbstractVector, paragon::AbstractVector)
 
 Checks if the elements in `candidate` are a cyclic permutation of the elements
@@ -354,55 +324,6 @@ function distance(x::AbstractVector{N}, y::AbstractVector{N}; p::Real=N(2)) wher
     return norm(x - y, p)
 end
 
-@static if VERSION < v"1.8"
-    """
-        allequal(x)
-
-    Check whether all elements in a sequence are equal
-
-    ### Input
-
-    - `x` -- sequence
-
-    ### Output
-
-    `true` iff all elements in `x` are equal.
-
-    ### Notes
-
-    The code is taken from [here](https://stackoverflow.com/a/47578613).
-
-    This function is available in Julia `Base` since v1.8. Hence it is only defined
-    here if a Julia version below v1.8 is used.
-    """
-    function allequal(x)
-        length(x) < 2 && return true
-        x1 = @inbounds x[1]
-        @inbounds for xi in x
-            xi == x1 || return false
-        end
-        return true
-    end
-end
-
-# if `vector` has exactly one non-zero entry, return its index
-# otherwise return 0
-function find_unique_nonzero_entry(vector::AbstractVector{N}) where {N}
-    res = 0
-    for (i, v) in enumerate(vector)
-        if v != zero(N)
-            if res != 0
-                # at least two non-zero entries
-                return 0
-            else
-                # first non-zero entry so far
-                res = i
-            end
-        end
-    end
-    return res
-end
-
 function append_zeros(v::AbstractVector{N}, n::Int) where {N}
     return vcat(v, zeros(N, n))
 end
@@ -494,56 +415,6 @@ function ispermutation(u::AbstractVector{T}, v::AbstractVector) where {T}
         end
     end
     return true
-end
-
-"""
-    substitute(substitution::Dict{Int, T}, x::AbstractVector{T}) where {T}
-
-Apply a substitution to a given vector.
-
-### Input
-
-- `substitution` -- substitution (a mapping from an index to a new value)
-- `x`            -- vector
-
-### Output
-
-A fresh vector corresponding to `x` after `substitution` was applied.
-"""
-function substitute(substitution::Dict{Int,T}, x::AbstractVector{T}) where {T}
-    return substitute!(substitution, copy(x))
-end
-
-"""
-    substitute!(substitution::Dict{Int, T}, x::AbstractVector{T}) where {T}
-
-Apply a substitution to a given vector.
-
-### Input
-
-- `substitution` -- substitution (a mapping from an index to a new value)
-- `x`            -- vector (modified in this function)
-
-### Output
-
-The same (but see the Notes below) vector `x` but after `substitution` was
-applied.
-
-### Notes
-
-The vector `x` is modified in-place if it has type `Vector` or `SparseVector`.
-Otherwise, we first create a new `Vector` from it.
-"""
-function substitute!(substitution::Dict{Int,T}, x::AbstractVector{T}) where {T}
-    return substitute!(Vector(x), substitution)
-end
-
-function substitute!(substitution::Dict{Int,T},
-                     x::Union{Vector{T},SparseVector{T}}) where {T}
-    for (index, value) in substitution
-        x[index] = value
-    end
-    return x
 end
 
 function isupwards(vec)

--- a/src/Comparison/Comparison.jl
+++ b/src/Comparison/Comparison.jl
@@ -10,12 +10,13 @@ using SparseArrays: SparseVector
 
 export set_rtol, set_ztol, set_atol, set_tolerance,
        _rtol, _ztol, _atol, default_tolerance,
-       _geq, _leq, _in, _isapprox, isapproxzero
+       _geq, _leq, _in, _isapprox, isapproxzero, isidentical
 
 include("tolerance.jl")
 include("isapproxzero.jl")
 include("isapprox.jl")
 include("inequality.jl")
 include("in.jl")
+include("isidentical.jl")
 
 end  # module

--- a/src/Comparison/isidentical.jl
+++ b/src/Comparison/isidentical.jl
@@ -1,0 +1,17 @@
+"""
+    isidentical(x::TX, y::TY) where {TX,TY}
+
+Comparison of objects that always fails if the objects have different types
+
+### Input
+
+- `x` -- first argument
+- `y` -- second argument
+
+### Output
+
+`true` iff `x == y` and `x` and `y` have the same type.
+"""
+function isidentical(x::TX, y::TY) where {TX,TY}
+    return TX == TY && x == y
+end

--- a/test/Arrays/SingleEntryVector.jl
+++ b/test/Arrays/SingleEntryVector.jl
@@ -1,58 +1,146 @@
-using ReachabilityBase.Arrays
+using ReachabilityBase.Arrays, Test, LinearAlgebra, SparseArrays
+using ReachabilityBase.Comparison: isidentical
 
 for N in [Float64, Float32, Rational{Int}]
-    x = SingleEntryVector(1, 100, N(10))
-    y = SingleEntryVector(1, 100, N(3))
-    z = SingleEntryVector(2, 100, N(-6))
+    x = SingleEntryVector(1, 3, N(-10))
+
+    # constructors
+    @test_throws ArgumentError SingleEntryVector(0, 2, N(1))
+    @test_throws ArgumentError SingleEntryVector(3, 2, N(1))
+    @test_throws ArgumentError SingleEntryVector(1, 0, N(1))
+    y = SingleEntryVector(1, 2, N(0))  # zero is a valid entry
+    @test iszero(y)
+    # type parameter
+    y = SingleEntryVector{N}(1, 3, N(-10))
+    @test isidentical(y, x)
+    # one-element default value
+    y = SingleEntryVector{N}(2, 3)
+    @test isidentical(y, SingleEntryVector(2, 3, N(1)))
 
     # getindex
-    e = x[1]
-    @test e isa N && e == N(10)
-    e = x[2]
-    @test e isa N && e == zero(N)
     @test_throws BoundsError x[0]
-    @test_throws BoundsError x[101]
+    @test_throws BoundsError x[6]
+    v = x[1]
+    @test v isa N && v == x.v
+    for i in 2:3
+        v = x[i]
+        @test v isa N && v == zero(N)
+    end
+
+    # size
+    @test size(x) == (3,)
+    @test_throws BoundsError size(x, 0)
+    @test size(x, 1) == 3
+    @test size(x, 2) == 1  # Base.size behavior for other indices
+
+    # negation
+    y = -x
+    @test isidentical(y, SingleEntryVector(1, 3, N(10)))
 
     # addition
-    res = x + y
-    @test res == SingleEntryVector(1, 100, N(13)) && typeof(res) == SingleEntryVector{N}
-    res = x + z
-    w = zeros(N, 100)
-    w[1] = N(10)
-    w[2] = N(-6)
-    @test res == w
+    @test_throws DimensionMismatch x + SingleEntryVector(1, 1, N(1))
+    # same index
+    y = SingleEntryVector(1, 3, N(-3))
+    z = x + y
+    @test isidentical(z, SingleEntryVector(1, 3, N(-13)))
+    # different index
+    y = SingleEntryVector(2, 3, N(-3))
+    z = x + y
+    @test z isa SparseVector{N} && z == sparsevec([1, 2], N[-10, -3], 3)
 
     # subtraction
-    res = x - y
-    @test res == SingleEntryVector(1, 100, N(7)) && typeof(res) == SingleEntryVector{N}
-    res = x - z
-    w = zeros(N, 100)
-    w[1] = N(10)
-    w[2] = N(6)
-    @test res == w
+    @test_throws DimensionMismatch x - SingleEntryVector(1, 1, N(1))
+    # same index
+    y = SingleEntryVector(1, 3, N(-3))
+    z = x - y
+    @test isidentical(z, SingleEntryVector(1, 3, N(-7)))
+    # different index
+    y = SingleEntryVector(2, 3, N(-3))
+    z = x - y
+    @test z isa SparseVector{N} && z == sparsevec([1, 2], N[-10, 3], 3)
 
-    x = SingleEntryVector(1, 100, N(-1))
-    y = SingleEntryVector(1, 100, N(-3))
-    z = SingleEntryVector(2, 100, N(-6))
-
-    # distance
-    @test distance(x, y) == distance(x, y; p=N(2)) == distance(x, y; p=N(Inf)) == N(2)
-    @test distance(x, z) == distance(x, z; p=N(2)) ≈ sqrt(N(37))
-    @test distance(x, z; p=N(Inf)) == N(6)
+    # matrix-vector multiplication
+    M = zeros(N, 1, 1)
+    @test_throws DimensionMismatch M * x
+    # Matrix
+    M = N[2 3 4; -9 -8 -7]
+    y = M * x
+    @test y isa Vector{N} && y == N[-20, 90]
+    # SparseMatrixCSC
+    M = sparse(M)
+    y = M * x
+    @test y isa SparseVector{N} && y == N[-20, 90]
+    # Diagonal
+    M = Diagonal(N[2])
+    @test_throws DimensionMismatch M * x
+    M = Diagonal(N[2, 3, 4])
+    y = M * x
+    @test isidentical(y, SingleEntryVector(1, 3, N(-20)))
 
     # At_mul_B
-    x = SingleEntryVector(2, 3, N(-2))
-    @test_throws DimensionMismatch At_mul_B(N[1 2; 3 4], x)
-    @test_throws DimensionMismatch At_mul_B(x, N[1 2; 3 4])
-    for y in (At_mul_B(N[1 2; 3 4; 5 6], x), At_mul_B(x, N[1 2; 3 4; 5 6]))
-        @test y isa Vector{N} && y == N[-6, -8]
+    # matrix/vector and vector/matrix
+    M = N[1 2; 3 4]
+    @test_throws DimensionMismatch At_mul_B(M, x)
+    @test_throws DimensionMismatch At_mul_B(x, M)
+    M = N[1 2; 3 4; 5 6]
+    for x in (At_mul_B(M, x), At_mul_B(x, M))
+        @test x isa Vector{N} && x == N[-10, -20]
     end
-    y = SingleEntryVector(1, 4, N(3))
+    # SingleEntryVector/SingleEntryVector
+    y = SingleEntryVector(1, 2, N(1))
     @test_throws DimensionMismatch At_mul_B(x, y)
+    # same index
     y = SingleEntryVector(1, 3, N(3))
     z = At_mul_B(x, y)
-    @test z isa Vector{N} && z == N[0]
+    @test z isa Vector{N} && z == N[-30]
+    # different index
     y = SingleEntryVector(2, 3, N(3))
     z = At_mul_B(x, y)
-    @test z isa Vector{N} && z == N[-6]
+    @test z isa Vector{N} && z == N[0]
+
+    # inner
+    y = SingleEntryVector(1, 2, N(3))
+    @test_throws DimensionMismatch inner(x, M, x)
+    @test_throws DimensionMismatch inner(y, M, y)
+    v = inner(x, M, y)
+    @test v isa N && v == dot(x, M * y) == N(-30)
+
+    # append_zeros
+    y = SingleEntryVector(2, 3, N(2))
+    z = append_zeros(y, 2)
+    @test isidentical(z, SingleEntryVector(2, 5, N(2)))
+
+    # prepend_zeros
+    z = prepend_zeros(y, 2)
+    @test isidentical(z, SingleEntryVector(4, 5, N(2)))
+
+    # norm
+    @test_throws ArgumentError norm(x, N(1 // 2))
+    v = norm(x)
+    @test v isa N && v == N(10)
+    for p in (1, 2, Inf)
+        v = norm(x, p)
+        @test v isa N && v == N(10)
+    end
+
+    # distance
+    y = SingleEntryVector(1, 2, N(2))
+    @test_throws DimensionMismatch distance(x, y)
+    y = SingleEntryVector(1, 3, N(-3))
+    @test_throws ArgumentError distance(x, y; p=N(1 // 2))
+    # same index
+    for (x1, x2) in ((x, y), (y, x))
+        @test distance(x1, x2) == distance(x1, x2; p=N(2)) == distance(x1, x2; p=N(Inf)) == N(7)
+    end
+    # different index
+    y = SingleEntryVector(2, 3, N(-6))
+    for (x1, x2) in ((x, y), (y, x))
+        @test distance(x, y) == distance(x, y; p=N(2)) == norm(N[-10, -6], N(2))
+        @test distance(x, y; p=N(Inf)) == N(10)
+    end
+
+    # abs_sum
+    M = N[-1 -2; 3 4; 5 6]
+    v = abs_sum(x, M)
+    @test v isa N && v == N(30)
 end

--- a/test/Arrays/array_operations.jl
+++ b/test/Arrays/array_operations.jl
@@ -1,47 +1,55 @@
-using ReachabilityBase.Arrays
-using ReachabilityBase.Comparison
+using ReachabilityBase.Arrays, Test, SparseArrays
+using ReachabilityBase.Comparison: isidentical
 
 for N in [Float64, Float32, Rational{Int}]
-    v1 = N[0, 4, 0]
-    v2 = sparsevec(N[2], N[4], 3)
-    @test v1 == v2
-    v1a = append_zeros(v1, 2)
-    v1p = prepend_zeros(v1, 2)
-    @test v1a == append_zeros(v2, 2) == N[0, 4, 0, 0, 0]
-    @test v1p == prepend_zeros(v2, 2) == N[0, 0, 0, 4, 0]
+    # same_sign
+    @test same_sign(zeros(N, 0))
+    A = reshape(N.(collect(1:8)), 2, 2, 2)
+    @test same_sign(A)
+    @test same_sign(-A)
+    A[1, 1, 1] = -1
+    @test !same_sign(A)
+    @test !same_sign(-A)
+    A[1, 1, 1] = 1
+    A[2, 2, 2] = -8
+    @test !same_sign(A)
+    @test !same_sign(-A)
+
+    # rectify
+    A = reshape(N.(collect(1:8)), 2, 2, 2)
+    A2 = rectify(A)
+    @test isidentical(A2, A)
+    A2 = rectify(-A)
+    A3 = zeros(N, 2, 2, 2)
+    @test isidentical(A2, A3)
 
     # argmaxabs
-    @test_throws AssertionError argmaxabs(N[])
-    @test argmaxabs(N[-4, -2, 3]) == 1
-    @test argmaxabs(N[-4, 5, 3]) == 2
-    @test argmaxabs(N[1, -2, 3]) == 3
+    @test_throws ArgumentError argmaxabs(zeros(N, 0, 1, 1))
+    @test argmaxabs(N[0, 0]) == 1
+    @test argmaxabs(reshape(N[-4, -2, 4, 2], 1, 2, 2)) == 1
+    @test argmaxabs(N[-4, 5, 4]) == 2
 end
 
 for N in [Float32, Float64]
-    # rationalize
-    x = [N(1), N(2), N(3)]
-    out = [1 // 1, 2 // 1, 3 // 1]
-    @test rationalize(x) == out
-    v = rationalize(BigInt, x)
-    @test v[1] isa Rational{BigInt}
-    @test rationalize(x; tol=2 * eps(N)) == out
+    to_3d(v) = reshape(v, 1, 2, 2)
 
-    # rand_pos_neg_zerosum_vector
-    x = rand_pos_neg_zerosum_vector(10; N=N)
-    @test isapproxzero(sum(x))
-    @test length(unique(x)) == length(x)
-    # test that the order is "first all positive, then all negative entries"
-    posneg = true
-    neg = false
-    for xi in x
-        if xi > zero(N)
-            if neg
-                posneg = false
-                break
-            end
-        elseif !neg
-            neg = true
-        end
-    end
-    @test posneg
+    # rationalize
+    A = to_3d(N[1, 2, 3, 4])
+    # default: Rational{Int}
+    A2 = rationalize(A)
+    A3 = to_3d(Rational{Int}[1, 2, 3, 4])
+    @test isidentical(A2, A3)
+    # tolerance
+    A2 = rationalize(A; tol=2 * eps(N))
+    @test isidentical(A2, A3)
+    # nested arrays
+    A2 = rationalize(Int, [A, A], 2 * eps(N))
+    isidentical(A2, [A3, A3])
+    # Rational{BigInt}
+    A2 = rationalize(BigInt, A)
+    A3 = to_3d(Rational{BigInt}[1, 2, 3, 4])
+    @test isidentical(A2, A3)
+    # tolerance
+    A2 = rationalize(BigInt, A; tol=2 * eps(N))
+    @test isidentical(A2, A3)
 end

--- a/test/Arrays/array_operations.jl
+++ b/test/Arrays/array_operations.jl
@@ -28,6 +28,37 @@ for N in [Float64, Float32, Rational{Int}]
     @test argmaxabs(N[0, 0]) == 1
     @test argmaxabs(reshape(N[-4, -2, 4, 2], 1, 2, 2)) == 1
     @test argmaxabs(N[-4, 5, 4]) == 2
+
+    # nonzero_indices
+    @test isidentical(nonzero_indices(zeros(N, 2, 2, 2)), Int[])
+    v = N[1 0 -2 0 3]
+    for v2 in (v, sparsevec(v))
+        @test isidentical(nonzero_indices(v2), [1, 3, 5])
+    end
+
+    # find_unique_nonzero_entry
+    @test find_unique_nonzero_entry(zeros(N, 2, 2, 2)) == 0
+    @test find_unique_nonzero_entry(ones(N, 2, 2, 2)) == 0
+    @test find_unique_nonzero_entry(N[0, 1, 0]) == 2
+
+    # substitute/substitute!
+    substitution = Dict{Int,N}(1 => N(1), 3 => (3))
+    @test_throws BoundsError substitute(substitution, N[0, 0])
+    for (A, B) in ((reshape(N[0, 0, 0], 3, 1, 1), reshape(N[1, 0, 3], 3, 1, 1)),
+                   (sparsevec(N[0, 0, 0]), sparsevec(N[1, 0, 3])))
+        @test isidentical(substitute(substitution, A), B)
+        A2 = copy(A)
+        substitute!(substitution, A2)
+        @test isidentical(A2, B)
+    end
+
+    @static if VERSION < v"1.8"
+        # allequal
+        @test allequal(N[])
+        @test allequal(reshape(N[0], 1, 1, 1))
+        @test allequal(N[0, 0])
+        @test !allequal(N[0, 1])
+    end
 end
 
 for N in [Float32, Float64]

--- a/test/Arrays/array_operations.jl
+++ b/test/Arrays/array_operations.jl
@@ -4,12 +4,11 @@ using ReachabilityBase.Comparison
 for N in [Float64, Float32, Rational{Int}]
     v1 = N[0, 4, 0]
     v2 = sparsevec(N[2], N[4], 3)
-    v3 = SingleEntryVector(2, 3, N(4))
-    @test v1 == v2 == v3
+    @test v1 == v2
     v1a = append_zeros(v1, 2)
     v1p = prepend_zeros(v1, 2)
-    @test v1a == append_zeros(v2, 2) == append_zeros(v3, 2) == N[0, 4, 0, 0, 0]
-    @test v1p == prepend_zeros(v2, 2) == prepend_zeros(v3, 2) == N[0, 0, 0, 4, 0]
+    @test v1a == append_zeros(v2, 2) == N[0, 4, 0, 0, 0]
+    @test v1p == prepend_zeros(v2, 2) == N[0, 0, 0, 4, 0]
 
     # argmaxabs
     @test_throws AssertionError argmaxabs(N[])

--- a/test/Arrays/arrays.jl
+++ b/test/Arrays/arrays.jl
@@ -49,11 +49,7 @@ for N in [Float64, Rational{Int}, Float32]
     A = N[1 4; 2 5; 3 6]
     x1 = N[0, 2, 0]
     y1 = N[3, 0]
-    x2 = SingleEntryVector(2, 3, N(2))
-    y2 = SingleEntryVector(1, 2, N(3))
-    @test -x2 == SingleEntryVector(2, 3, N(-2))
-    @test inner(x1, A, y1) == dot(x1, A * y1) == inner(x2, A, y2) ==
-          dot(x2, A * y2) == N(12)
+    @test inner(x1, A, y1) == dot(x1, A * y1)
 
     x = N[0, 1, -1]
     @test rectify(x) == N[0, 1, 0]

--- a/test/Arrays/arrays.jl
+++ b/test/Arrays/arrays.jl
@@ -39,20 +39,10 @@ for N in [Float64, Rational{Int}, Float32]
     C = N[1e-16 0; 0 -1e-16]
     @test remove_zero_columns(C) == (N <: AbstractFloat ? zeros(N, 2, 0) : C)
 
-    # substitution
-    x = N[1, 2, 3]
-    substitution = Dict(1 => N(4), 3 => N(0))
-    @test substitute(substitution, x) == N[4, 2, 0]
-    substitute!(substitution, x)
-    @test x == N[4, 2, 0]
-
     A = N[1 4; 2 5; 3 6]
     x1 = N[0, 2, 0]
     y1 = N[3, 0]
     @test inner(x1, A, y1) == dot(x1, A * y1)
-
-    x = N[0, 1, -1]
-    @test rectify(x) == N[0, 1, 0]
 
     # approximate permutation check
     v1 = [N[1, 2], N[2, 3], N[3, 4]]
@@ -81,12 +71,6 @@ for N in [Float64, Rational{Int}, Float32]
     V = [sparsevec([2], N[2]), sparsevec([1, 2], N[1, 3])]
     M = to_matrix(V)
     @test M isa SparseMatrixCSC{N} && M == M0
-
-    # same sign
-    A = (N isa AbstractFloat) ? rand(N, 100, 100) : ones(N, 100, 100)
-    @test same_sign(A; optimistic=true) == same_sign(A; optimistic=false) == true
-    A[50, 50] = N(-1)
-    @test same_sign(A; optimistic=true) == same_sign(A; optimistic=false) == false
 
     # ============================================
     # Corresponding vector types and matrix types

--- a/test/Arrays/vector_operations.jl
+++ b/test/Arrays/vector_operations.jl
@@ -1,4 +1,5 @@
 using ReachabilityBase.Arrays
+using ReachabilityBase.Comparison: isapproxzero
 
 for N in [Float64, Float32, Rational{Int}]
     v1 = N[2, 1]
@@ -6,4 +7,34 @@ for N in [Float64, Float32, Rational{Int}]
     @test isabove(N[2, 0], v1, v2)
     @test !isabove(N[1, 3], v1, v2)
     @test !isabove(N[2, 2], v1, v2) && !isabove(N[0, 0], v1, v2)  # perpendicular
+
+    # append_zeros / prepend_zeros
+    v1 = N[0, 4, 0]
+    v2 = sparsevec(N[2], N[4], 3)
+    @test v1 == v2
+    v1a = append_zeros(v1, 2)
+    v1p = prepend_zeros(v1, 2)
+    @test v1a == append_zeros(v2, 2) == N[0, 4, 0, 0, 0]
+    @test v1p == prepend_zeros(v2, 2) == N[0, 0, 0, 4, 0]
+end
+
+for N in [Float64, Float32]
+    # rand_pos_neg_zerosum_vector
+    x = rand_pos_neg_zerosum_vector(10; N=N)
+    @test isapproxzero(sum(x))
+    @test length(unique(x)) == length(x)
+    # test that the order is "first all positive, then all negative entries"
+    posneg = true
+    neg = false
+    for xi in x
+        if xi > zero(N)
+            if neg
+                posneg = false
+                break
+            end
+        elseif !neg
+            neg = true
+        end
+    end
+    @test posneg
 end

--- a/test/Comparison/comparison.jl
+++ b/test/Comparison/comparison.jl
@@ -1,4 +1,9 @@
-using ReachabilityBase.Comparison
+using ReachabilityBase.Comparison, Test
+
+# isidentical
+@test isidentical(1, 1)
+@test !isidentical(1, 2)
+@test !isidentical(1, 1.0)
 
 # approximate <=
 @test _leq(2e-15, 1e-15) && _leq(1e-15, 2e-15)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using Random: GLOBAL_RNG, seed!
 seed!(1234)  # fix RNG seed for reproducibility
 
 @testset "Arrays" begin
+    @testset "SingleEntryVector" begin
+        include("Arrays/SingleEntryVector.jl")
+    end
     @testset "array_operations" begin
         include("Arrays/array_operations.jl")
     end
@@ -22,9 +25,6 @@ seed!(1234)  # fix RNG seed for reproducibility
     end
     @testset "vector_operations" begin
         include("Arrays/vector_operations.jl")
-    end
-    @testset "SingleEntryVector" begin
-        include("Arrays/SingleEntryVector.jl")
     end
 end
 @testset "Comparison" begin


### PR DESCRIPTION
This branch is based on #102.

The only notable differences are:
- `same_sign` lost its strange optional argument `optimistic`.
- `substitute!` does not create a `Vector` anymore in some cases. Rationale: Mutating functions should just mutate. If the input is not mutable, this is a user errors.