### PR TITLE
Add `isidentical` for strict comparison with same type

### DIFF
--- a/docs/src/lib/Comparison.md
+++ b/docs/src/lib/Comparison.md
@@ -15,6 +15,12 @@ CurrentModule = ReachabilityBase.Comparison
 Comparison
 ```
 
+## Exact comparison
+
+```@docs
+isidentical
+```
+
 ## Tolerance
 
 ```@docs

--- a/src/Comparison/Comparison.jl
+++ b/src/Comparison/Comparison.jl
@@ -10,12 +10,13 @@ using SparseArrays: SparseVector
 
 export set_rtol, set_ztol, set_atol, set_tolerance,
        _rtol, _ztol, _atol, default_tolerance,
-       _geq, _leq, _in, _isapprox, isapproxzero
+       _geq, _leq, _in, _isapprox, isapproxzero, isidentical
 
 include("tolerance.jl")
 include("isapproxzero.jl")
 include("isapprox.jl")
 include("inequality.jl")
 include("in.jl")
+include("isidentical.jl")
 
 end  # module

--- a/src/Comparison/isidentical.jl
+++ b/src/Comparison/isidentical.jl
@@ -1,0 +1,17 @@
+"""
+    isidentical(x::TX, y::TY) where {TX,TY}
+
+Comparison of objects that always fails if the objects have different types
+
+### Input
+
+- `x` -- first argument
+- `y` -- second argument
+
+### Output
+
+`true` iff `x == y` and `x` and `y` have the same type.
+"""
+function isidentical(x::TX, y::TY) where {TX,TY}
+    return TX == TY && x == y
+end

--- a/test/Comparison/comparison.jl
+++ b/test/Comparison/comparison.jl
@@ -1,4 +1,9 @@
-using ReachabilityBase.Comparison
+using ReachabilityBase.Comparison, Test
+
+# isidentical
+@test isidentical(1, 1)
+@test !isidentical(1, 2)
+@test !isidentical(1, 1.0)
 
 # approximate <=
 @test _leq(2e-15, 1e-15) && _leq(1e-15, 2e-15)


### PR DESCRIPTION
Is the name `isidentical` reasonable? I wanted it to be quite short because it is intended to be used in tests a lot.