### PR TITLE
Use latest version of JuliaFormatter again

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache artifacts
         uses: julia-actions/cache@v3
       - name: Install JuliaFormatter and format
-        run: julia -e 'import Pkg; Pkg.add(name="JuliaFormatter", version=v"1.0.62"); using JuliaFormatter; format(".")'
+        run: julia -e 'import Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format(".")'
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v8

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(; sitename="ReachabilityBase.jl",
          pagesonly=true,
          pages=["Home" => "index.md",
                 "Library" => Any[
-                                 #
+                    #
                                  "Assertions" => "lib/Assertions.md",
                                  "Require" => "lib/Require.md",
                                  "Comparison" => "lib/Comparison.md",
@@ -26,8 +26,8 @@ makedocs(; sitename="ReachabilityBase.jl",
                                  "Timing" => "lib/Timing.md",
                                  "CurrentPath" => "lib/CurrentPath.md",
                                  "Basetype" => "lib/Basetype.md"
-                                 #
-                                 ],
+                    #
+                    ],
                 "About" => "about.md"])
 
 deploydocs(; repo="github.com/JuliaReach/ReachabilityBase.jl.git",

--- a/src/Assertions/Assertions.jl
+++ b/src/Assertions/Assertions.jl
@@ -16,7 +16,7 @@ export activate_assertions,
 
 # override Base.@assert
 macro assert(exs...)
-    quote
+    return quote
         if $__module__.are_assertions_enabled()
             Base.@assert $(map(esc, exs)...)
         end


### PR DESCRIPTION
The latest JuliaFormatter behavior is sufficiently similar to v1. See #96.

The build error is only with the Codecov upload. In other repos it used to work a few hours ago. Maybe just a temporary hiccup...